### PR TITLE
Automatically trust SSL certs for built-in repos

### DIFF
--- a/src/Repository/Config/Builtin/WordPressComThemes.php
+++ b/src/Repository/Config/Builtin/WordPressComThemes.php
@@ -28,6 +28,7 @@ class WordPressComThemes extends SVNRepositoryConfig {
 			'cache-handler' => [ $this, 'cache' ],
 			// cache for one week - these rarely change
 			'cache-ttl' => 604800,
+			'trust-cert' => true,
 		];
 		parent::__construct();
 	}

--- a/src/Repository/Config/Builtin/WordPressCore.php
+++ b/src/Repository/Config/Builtin/WordPressCore.php
@@ -18,6 +18,7 @@ class WordPressCore extends SVNRepositoryConfig {
 		'package-types' => [ 'wordpress-core' => [ 'wordpress', 'wordpress-core' ] ],
 		'name-filter' => [ __CLASS__, 'filterProvider' ],
 		'package-filter' => [ __CLASS__, 'filterPackage' ],
+		'trust-cert' => true,
 	];
 
 	/**

--- a/src/Repository/Config/Builtin/WordPressDevelop.php
+++ b/src/Repository/Config/Builtin/WordPressDevelop.php
@@ -18,6 +18,7 @@ class WordPressDevelop extends SVNRepositoryConfig {
 		'package-types' => [ 'wordpress-develop' => [ 'wordpress', 'wordpress-core' ] ],
 		'name-filter' => [ __CLASS__, 'filterProvider' ],
 		'package-filter' => [ __CLASS__, 'filterPackage' ],
+		'trust-cert' => true,
 	];
 
 	/**

--- a/src/Repository/Config/Builtin/WordPressPlugins.php
+++ b/src/Repository/Config/Builtin/WordPressPlugins.php
@@ -30,6 +30,7 @@ class WordPressPlugins extends SVNRepositoryConfig {
 			'cache-handler' => [ $this, 'cache' ],
 			// store the cache for however long the default is - it will likely get invalidated before then
 			'cache-ttl' => 'config',
+			'trust-cert' => true,
 		];
 		parent::__construct();
 	}

--- a/src/Repository/Config/Builtin/WordPressThemes.php
+++ b/src/Repository/Config/Builtin/WordPressThemes.php
@@ -28,6 +28,7 @@ class WordPressThemes extends SVNRepositoryConfig {
 			'cache-handler' => [ $this, 'cache' ],
 			// store the cache for however long the default is - it will likely get invalidated before then
 			'cache-ttl' => 'config',
+			'trust-cert' => true,
 		];
 		parent::__construct();
 	}

--- a/src/Repository/Config/Builtin/WordPressVIP.php
+++ b/src/Repository/Config/Builtin/WordPressVIP.php
@@ -21,6 +21,7 @@ class WordPressVIP extends SVNRepositoryConfig {
 		'package-filter' => [ __CLASS__, 'filterPackage' ],
 		// cache for one week - these change infrequently
 		'cache-ttl' => 604800,
+		'trust-cert' => true,
 	];
 
 	static function filterProvider( $name, $path, $url ) {

--- a/src/Repository/Config/SVNRepositoryConfig.php
+++ b/src/Repository/Config/SVNRepositoryConfig.php
@@ -46,6 +46,8 @@ class SVNRepositoryConfig extends RepositoryConfig {
 		'cache-ttl' => 0,
 		// provider cache file
 		'cache-file' => 'providers.json',
+		// should the server cert be automatically trusted?
+		'trust-cert' => false,
 	];
 
 	/**

--- a/src/Repository/SVNRepository.php
+++ b/src/Repository/SVNRepository.php
@@ -67,7 +67,7 @@ class SVNRepository extends ComposerRepository {
 		$this->vendors = $repoConfig->get( 'vendors' );
 		$this->defaultVendor = key( $this->vendors );
 
-		// set the SvnUtil for all instantiated classes to use
+		// create an SvnUtil to execute commands
 		$this->SvnUtil = new SvnUtil( $io, $repoConfig->get( 'trust-cert' ) );
 	}
 

--- a/src/Repository/SVNRepository.php
+++ b/src/Repository/SVNRepository.php
@@ -28,7 +28,7 @@ use Composer\Semver\Constraint\Constraint;
  */
 class SVNRepository extends ComposerRepository {
 
-	protected $SvnUtil;
+	protected $svnUtil;
 	protected $providerHash; // map {provider name} => {provider url}
 	protected $distUrl;
 	protected $plugin; //the plugin class that instantiated this repository
@@ -68,7 +68,7 @@ class SVNRepository extends ComposerRepository {
 		$this->defaultVendor = key( $this->vendors );
 
 		// create an SvnUtil to execute commands
-		$this->SvnUtil = new SvnUtil( $io, $repoConfig->get( 'trust-cert' ) );
+		$this->svnUtil = new SvnUtil( $io, $repoConfig->get( 'trust-cert' ) );
 	}
 
 	public function findPackage( $name, $constraint ) {
@@ -177,7 +177,7 @@ class SVNRepository extends ComposerRepository {
 					if ( $this->io->isVerbose() ) {
 						$this->io->writeError( "Fetching available versions for $name" );
 					}
-					$pkgRaw = $this->SvnUtil->execute( 'ls', "$providerUrl/$relPath" );
+					$pkgRaw = $this->svnUtil->execute( 'ls', "$providerUrl/$relPath" );
 				} catch( \RuntimeException $e ) {
 					// @todo maybe don't throw an exception and just pass this one up?
 					throw new \RuntimeException( "SVN Error: Could not retrieve package listing for $name. " . $e->getMessage() );
@@ -312,7 +312,7 @@ class SVNRepository extends ComposerRepository {
 				if ( substr( $path, -1 ) === '/' ) {
 					// try to get a listing of providers
 					try {
-						$providersRaw = $this->SvnUtil->execute( 'ls', $url );
+						$providersRaw = $this->svnUtil->execute( 'ls', $url );
 					} catch( \RuntimeException $e ) {
 						throw new \RuntimeException( "SVN Error: Could not retrieve provider listing from $url " . $e->getMessage() );
 					}

--- a/src/Repository/SVNRepository.php
+++ b/src/Repository/SVNRepository.php
@@ -28,7 +28,7 @@ use Composer\Semver\Constraint\Constraint;
  */
 class SVNRepository extends ComposerRepository {
 
-	static protected $SvnUtil;
+	protected $SvnUtil;
 	protected $providerHash; // map {provider name} => {provider url}
 	protected $distUrl;
 	protected $plugin; //the plugin class that instantiated this repository
@@ -68,9 +68,7 @@ class SVNRepository extends ComposerRepository {
 		$this->defaultVendor = key( $this->vendors );
 
 		// set the SvnUtil for all instantiated classes to use
-		if ( !isset( self::$SvnUtil ) ) {
-			self::$SvnUtil = new SvnUtil( $io );
-		}
+		$this->SvnUtil = new SvnUtil( $io, $repoConfig->get( 'trust-cert' ) );
 	}
 
 	public function findPackage( $name, $constraint ) {
@@ -179,7 +177,7 @@ class SVNRepository extends ComposerRepository {
 					if ( $this->io->isVerbose() ) {
 						$this->io->writeError( "Fetching available versions for $name" );
 					}
-					$pkgRaw = self::$SvnUtil->execute( 'ls', "$providerUrl/$relPath" );
+					$pkgRaw = $this->SvnUtil->execute( 'ls', "$providerUrl/$relPath" );
 				} catch( \RuntimeException $e ) {
 					// @todo maybe don't throw an exception and just pass this one up?
 					throw new \RuntimeException( "SVN Error: Could not retrieve package listing for $name. " . $e->getMessage() );
@@ -314,7 +312,7 @@ class SVNRepository extends ComposerRepository {
 				if ( substr( $path, -1 ) === '/' ) {
 					// try to get a listing of providers
 					try {
-						$providersRaw = self::$SvnUtil->execute( 'ls', $url );
+						$providersRaw = $this->SvnUtil->execute( 'ls', $url );
 					} catch( \RuntimeException $e ) {
 						throw new \RuntimeException( "SVN Error: Could not retrieve provider listing from $url " . $e->getMessage() );
 					}

--- a/src/Util/Svn.php
+++ b/src/Util/Svn.php
@@ -13,9 +13,27 @@ use Composer\Config;
 class Svn {
 
 	protected $util;
+	protected $trustCert;
 
-	function __construct( IOInterface $io ) {
+	function __construct( IOInterface $io, $trustCert = false ) {
 		$this->util = new SvnUtil( '', $io, new Config );
+		$this->setCertTrusted( $trustCert );
+	}
+
+	/**
+	 * Set whether we will trust the the SSL certificate automatically.
+	 * @param bool $bool yas/nah
+	 */
+	function setCertTrusted( $bool ) {
+		$this->trustCert = (bool) $bool;
+	}
+
+	/**
+	 * Are we automatically trusting the cert?
+	 * @return bool yas/nah
+	 */
+	function isCertTrusted() {
+		return $this->trustCert;
 	}
 
 	/**
@@ -25,6 +43,11 @@ class Svn {
 	 * @return string          response
 	 */
 	function execute( $command, $url ) {
+		// is this an https connection, and do we trust it automatically?
+		if ( strncasecmp( $url, 'https', 5 ) === 0 && $this->isCertTrusted() ) {
+			// let svn trust the certificate without prompt
+			$command .= ' --non-interactive --trust-server-cert';
+		}
 		return $this->util->execute( "svn $command", $url );
 	}
 


### PR DESCRIPTION
Allows SVN repos to be configured so that their certificates are automatically trusted. This fixes an issue where composer would just fail as it was not able to proxy the question from SVN about whether to trust the certificate.

All built-in SVN repos are set to be trusted; user-defined repos will have to be explicitly set to be trusted in their config OR the user must run `svn ls $URL` and permanently trust the host for the SVN repo to work.

Fixes #9 
